### PR TITLE
Added support for eputil and epfmt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ CaltechDATA_Logo_cropped.png
 build/
 dist/
 ames.egg-info/
+# Test files
+*.csv

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist/
 ames.egg-info/
 # Test files
 *.csv
+updates

--- a/ames/converters/__init__.py
+++ b/ames/converters/__init__.py
@@ -1,0 +1,3 @@
+
+from .codemeta_to_datacite import codemeta_to_datacite
+from .epfmt import eprint_as_xml, eprint_as_json

--- a/ames/converters/epfmt.py
+++ b/ames/converters/epfmt.py
@@ -1,0 +1,58 @@
+#
+# epfmt is a Python 3.7 wrapper for the functionality of
+# the epfmt command line tool which is part of the eprinttools Go
+# package
+#
+# For the Go package see https://github.com/caltechlibrary/eprinttools.
+#
+import os
+import io
+import json
+import sys
+from subprocess import run, Popen, PIPE
+
+
+#
+# eprint_as_xml takes a Python dict of EPrint content like
+# that fetched with eputil returns the object as EPrint XML.
+#
+def eprint_as_xml(eprint_obj):
+    src = json.dumps(eprint_obj)
+    #if not isinstance(src, bytes):
+    #    src = src.encode('utf-8')
+    cmd = ['epfmt', '-xml']
+    try:
+        p = run(cmd, input = src.encode('utf-8'), capture_output = True)
+    except Exception as e:
+        sys.stderr.write(f"{e}\n")
+    exit_code = p.returncode
+    if exit_code != 0:
+        print(f"ERROR: {' '.join(cmd)}, exit code {exit_code}")
+        return None
+    value = p.stdout
+    if not isinstance(value, bytes):
+        value = value.encode('utf8')
+    return value.decode()
+
+#
+# eprint_as_json takes a Python Dict of EPrint content
+# like that fetch with eputil returns the object in JSON format.
+#
+def eprint_as_json(eprint_obj):
+    src = json.dumps(eprint_obj)
+    if not isinstance(src, bytes):
+        src = src.encode('utf-8')
+    cmd = ['epfmt', '-json']
+    try:
+        p = run(cmd, input = src, capture_output = True)
+    except Exception as e:
+        sys.stderr.write(f"{e}\n")
+    exit_code = p.returncode
+    if exit_code != 0:
+        print(f"ERROR: {' '.join(cmd)}, exit code {exit_code}")
+        return None
+    value = p.stdout
+    if not isinstance(value, bytes):
+        value = value.encode('utf8')
+    return value.decode()
+

--- a/ames/harvesters/__init__.py
+++ b/ames/harvesters/__init__.py
@@ -3,3 +3,4 @@ from .cd_github import get_cd_github
 from .caltechdata import get_caltechdata
 from .caltechfeeds import get_caltechfeed
 from .matomo import get_downloads
+from .eputil import get_eprint_keys, get_eprints, get_eprint

--- a/ames/harvesters/eputil.py
+++ b/ames/harvesters/eputil.py
@@ -1,0 +1,129 @@
+#
+# eputil.py is a Python 3.7 wrapper for the Go eprinttools
+# eputil command line program.
+# 
+# For Go package see https://github.com/caltechlibrary/eprinttools.
+#
+import os
+import json
+import sys
+from subprocess import run, Popen, PIPE
+from datetime import datetime, timedelta
+
+
+#
+# get_eprint_keys  returns a list of keys available from the
+# EPrints rest API indicated in the provided eprint_url. 
+#
+# The eprint_url often is in the form containing a username/password
+# for access the API. E.g. 
+#
+#     'https://jane.doe:secret@eprint.example.edu'
+#
+def get_eprint_keys(eprint_url):
+    cmd = ['eputil']
+    cmd.append('-json')
+    cmd.append(eprint_url + '/rest/eprint/')
+    try:
+        p = run(cmd, capture_output = True)
+    except Exception as e:
+        sys.stderr.write(f"{e}\n")
+
+    exit_code = p.returncode
+    if exit_code != 0:
+        print(f"ERROR: {' '.join(cmd)}, exit code {exit_code}")
+        return None
+    value = p.stdout
+    if not isinstance(value, bytes):
+        value = value.encode('utf8')
+    src = value.decode()
+    if type(src) == str:
+        if src == "":
+            return []
+        keys = []
+        l = json.loads(src)
+        for k in l:
+            keys.append(f"{k}")
+        return keys
+    else:
+        print(f"ERROR: wrong type {type(src)} for {src}")
+        return None
+
+#
+# get_eprint returns a single EPrint element for given EPrint ID.
+# via the EPrints rest API indicated in the provided eprint_url. 
+#
+# The eprint_url often is in the form containing a username/password
+# for access the API. E.g. 
+#
+#     'https://jane.doe:secret@eprint.example.edu'
+#
+def get_eprint(eprint_url, eprint_id):
+    eprint = {}
+    cmd = ['eputil']
+    cmd.append('-json')
+    cmd.append(eprint_url + '/rest/eprint/' + eprint_id + '.xml')
+    try:
+        p = run(cmd, capture_output = True)
+    except Exception as e:
+        sys.stderr.write(f"{e}\n")
+
+    exit_code = p.returncode
+    if exit_code != 0:
+        print(f"ERROR: {' '.join(cmd)}, exit code {exit_code}")
+        return None
+    value = p.stdout
+    if not isinstance(value, bytes):
+        value = value.encode('utf8')
+    src = value.decode()
+    if type(src) == str:
+        if src == "":
+            return {} 
+        obj = json.loads(src)
+        if 'eprint' in obj and len(obj['eprint']) > 0:
+            return obj['eprint'][0]
+        return None
+    else:
+        print(f"ERROR: wrong type {type(src)} for {src}")
+        return None
+
+#
+# get_eprints returns an EPrint element in List form
+# for given EPrint ID via the EPrints rest API indicated in the 
+# provided eprint_url (the outer XML is <eprints>... rather
+# than the inner XML of <eprints><eprint>...)
+#
+# The eprint_url often is in the form containing a username/password
+# for access the API. E.g. 
+#
+#     'https://jane.doe:secret@eprint.example.edu'
+#
+def get_eprints(eprint_url, eprint_id):
+    eprints = []
+    eprint = {}
+    cmd = ['eputil']
+    cmd.append('-json')
+    cmd.append(eprint_url + '/rest/eprint/' + eprint_id + '.xml')
+    try:
+        p = run(cmd, capture_output = True)
+    except Exception as e:
+        sys.stderr.write(f"{e}\n")
+    exit_code = p.returncode
+    if exit_code != 0:
+        print(f"ERROR: {' '.join(cmd)}, exit code {exit_code}")
+        return None
+    value = p.stdout
+    if not isinstance(value, bytes):
+        value = value.encode('utf8')
+    src = value.decode()
+    if type(src) == str:
+        if src == "":
+            return []
+        obj = json.loads(src)
+        if 'eprint' in obj and len(obj['eprint']) > 0:
+            return obj
+        return None
+    else:
+        print(f"ERROR: wrong type {type(src)} for {src}")
+        return None
+

--- a/run_eprint_attach_orcid.py
+++ b/run_eprint_attach_orcid.py
@@ -16,18 +16,18 @@ def usage(msg = "", exit_code = 0):
     app_name = os.path.basename(sys.argv[0])
     print(f'''USAGE: 
     
-    {app_name} URL_TO_EPRINTS \\
-        CREATOR_CSV_FILE [EXPORT_DIRECTORY]
+    {app_name} \\
+        URL_TO_EPRINTS \\
+        CREATOR_CSV_FILE EXPORT_DIRECTORY
 
-This script reads the CREATOR_ID from CREATOR_CSV_FILE and
-retrieves the ORCID and EPrint IDs to update.
+This script reads the creator id from CREATOR_CSV_FILE and
+retrieves the ORCID and EPrint IDs to updated generating
+EPrints XML in EXPORT_DIRECTORY.
 
-EXPORT_DIRECTORY if will hold the eprint XML generated
-for import via the formal EPrints epadmin tool. The name
+EXPORT_DIRECTORY holds the eprint XML generated
+for use with the EPrints epadmin tools. The name
 is in the form of EXPORT_DIRECTORY/EPRINT_ID.xml where 
-EPRINT_ID is the numeric eprint id number. If the 
-EXPORT_DIRECTORY is not provided it will put the XML files
-in the current directory.
+EPRINT_ID is the numeric eprint id number. 
 
 EXAMPLE:
 
@@ -35,8 +35,9 @@ After running run_eprint_report creator ... use the CSV
 rows to update a specific creator id of JONES-J. The exported
 eprint XML will be placed inthe updates directory.
 
-    {app_name} 'https://username:secret@eprint.example.edu' \\
-            creator_report.csv updates
+    {app_name} \\
+        'https://username:secret@eprint.example.edu' \\
+        creator_report.csv updates
 
 ''')
     if msg != "":
@@ -44,20 +45,14 @@ eprint XML will be placed inthe updates directory.
         print(msg)
     sys.exit(exit_code)
 
-if len(sys.argv) < 3:
-    usage("Expected URL to EPrints, CSV Creator report filename", 1)
+if len(sys.argv) < 4:
+    usage("", 1)
 
-eprint_url, csv_filename = sys.argv[1], sys.argv[2]
+eprint_url, csv_filename, export_folder = sys.argv[1], sys.argv[2], sys.argv[3]
 
-export_folder = '.'
-if len(sys.argv) == 4:
-    export_folder = sys.argv[3]
-
-#FIXME: Need to generate find all the authors with ORCID in
-# given eprint records so that we can do one update and fix that
-# record.
 
 # Iterate over the rows of the Creator Report CSV file
+# And find the eprint ids that need updating.
 print(f"Processing {csv_filename}")
 records = {} 
 with open(csv_filename) as f:
@@ -88,8 +83,9 @@ with open(csv_filename) as f:
                     records[eprint_id][creator_id] = orcid
 
 
+# For each record find the eprint record to update
+# and update creators and render out EPrint XML
 print(f"Generating EPrints XML")
-# For each record find the eprint record, update the creators with orcids
 for eprint_id in records:
     # Fetch EPrint object
     o = get_eprints(eprint_url, eprint_id)

--- a/run_eprint_attach_orcid.py
+++ b/run_eprint_attach_orcid.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+#
+# Attach an orcid to a creator given an REST URL API, eprint id
+# number, the creator id and orcid. Output a an update EPrintXML
+# suitable for importing with epadmin
+#
+import os
+import sys
+import csv
+from ames.harvesters import get_eprint_keys, get_eprints, get_eprint
+from ames.converters import eprint_as_xml, eprint_as_json
+
+
+def usage(msg = "", exit_code = 0):
+    app_name = os.path.basename(sys.argv[0])
+    print(f'''USAGE: 
+    
+    {app_name} URL_TO_EPRINTS \\
+        CREATOR_CSV_FILE CREATOR_ID [EXPORT_DIRECTORY]
+
+This script reads the CREATOR_ID from CREATOR_CSV_FILE and
+retrieves the ORCID and EPrint IDs to update.
+
+EXPORT_DIRECTORY if provided will hold the eprint XML generated
+for import via epadmin. If not provided it deposits the eprint
+XML in the current directory in the form of EPRINT_ID.xml where
+EPRINT_ID is the numeric eprint id number.
+
+EXAMPLE:
+
+After running run_eprint_report creator ... use the CSV
+rows to update a specific creator id of JONES-J. The exported
+eprint XML will be placed inthe updates directory.
+
+    {app_name} 'https://username:secret@eprint.example.edu' \\
+            creator_report.csv JONES-J \\
+            updates
+
+''')
+    if msg != "":
+        print("")
+        print(msg)
+    sys.exit(exit_code)
+
+if len(sys.argv) < 3:
+    usage("Expected URL to EPrints, CSV Creator report filename", 1)
+
+eprint_url, csv_filename, export_folder = sys.argv[1], sys.argv[2], sys.argv[3], '.'
+
+if len(sys.argv) == 4:
+    export_folder = sys.argv[3]
+
+# Iterate over the rows of the Creator Report CSV file
+records = {} 
+with open(csv_filename) as f:
+    table = csv.DictReader(f)
+    for row in table:
+        if 'orcid' in row:
+            if '|' in row['orcid']:
+                print(f"WARNING multiple orcids for {row['creator_id']}")
+            else:
+                print(f"Processing {row['creator_id']} -> {row['orcid']} -> {row['eprint_id']}")
+
+
+# Find the rows with an orcid
+# Find the eprint id numbers
+# generate the EPrint XML and save for update via epadmin import tool
+
+# # NOTE: We use get_eprints() because the XML we want should
+# # conform to what epadmin will expect for this record.
+# # E.g. <eprints><eprint> .... </eprint>...</eprints>
+# o = get_eprints(eprint_url, eprint_id)
+# if o == None:
+#     print(f"Failed to get record for eprint {eprint_id}")
+#     sys.exit(1)
+# if 'eprint' in o:
+#     # NOTE We're working with single records so let's pull out
+#     # our eprint element.
+#     obj = o['eprint'][0]
+#     if 'creators' in obj and 'items' in obj['creators']:
+#         items = obj['creators']['items']
+#         for item in items:
+#             if 'id' in item and item['id'] == creator_id:
+#                 item['orcid'] = orcid
+#                 break
+#         eprint_xml = eputils.eprint_as_xml(o)
+#         print(eprint_xml)

--- a/run_eprint_attach_orcid.py
+++ b/run_eprint_attach_orcid.py
@@ -51,6 +51,10 @@ eprint_url, csv_filename, export_folder = sys.argv[1], sys.argv[2], sys.argv[3],
 if len(sys.argv) == 4:
     export_folder = sys.argv[3]
 
+#FIXME: Need to generate find all the authors with ORCID in
+# given eprint records so that we can do one update and fix that
+# record.
+
 # Iterate over the rows of the Creator Report CSV file
 records = {} 
 with open(csv_filename) as f:
@@ -60,29 +64,17 @@ with open(csv_filename) as f:
             if '|' in row['orcid']:
                 print(f"WARNING multiple orcids for {row['creator_id']}")
             else:
-                print(f"Processing {row['creator_id']} -> {row['orcid']} -> {row['eprint_id']}")
+                print(f"Saving {row['eprint_id']} -> {row['creator_id']} -> {row['orcid']}")
+                eprint_id = row['eprint_id']
+                orcid = row['orcid']
+                creator_id = row['creator_id']
+                if not eprint_id in records:
+                    records[eprint_id] = {}
+                records[eprint_id][creator_id] = orcid
 
 
-# Find the rows with an orcid
-# Find the eprint id numbers
-# generate the EPrint XML and save for update via epadmin import tool
-
-# # NOTE: We use get_eprints() because the XML we want should
-# # conform to what epadmin will expect for this record.
-# # E.g. <eprints><eprint> .... </eprint>...</eprints>
-# o = get_eprints(eprint_url, eprint_id)
-# if o == None:
-#     print(f"Failed to get record for eprint {eprint_id}")
-#     sys.exit(1)
-# if 'eprint' in o:
-#     # NOTE We're working with single records so let's pull out
-#     # our eprint element.
-#     obj = o['eprint'][0]
-#     if 'creators' in obj and 'items' in obj['creators']:
-#         items = obj['creators']['items']
-#         for item in items:
-#             if 'id' in item and item['id'] == creator_id:
-#                 item['orcid'] = orcid
-#                 break
-#         eprint_xml = eputils.eprint_as_xml(o)
-#         print(eprint_xml)
+# For each record find the eprint record, update the creators with orcids
+for record in records:
+    # Fetch EPrint object
+    # For each creator id in record append in EPrint object
+    # Generate the EPrint XML and save for update via epadmin import tool

--- a/run_eprint_attach_orcid.py
+++ b/run_eprint_attach_orcid.py
@@ -3,7 +3,7 @@
 #
 # Attach an orcid to a creator given an REST URL API, eprint id
 # number, the creator id and orcid. Output a an update EPrintXML
-# suitable for importing with epadmin
+# suitable for importing as update.
 #
 import os
 import sys

--- a/run_eprint_report.py
+++ b/run_eprint_report.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+
+#
+# run_eprint_report.py provides a small number of common reports.
+# reports are generated as CSV files.
+#
+import os
+import sys
+import random
+from ames.harvesters import get_eprint_keys, get_eprints, get_eprint
+
+batch_size = 100
+
+def usage(msg = "", exit_code = 0):
+    app_name = os.path.basename(sys.argv[0])
+    print(f'''USAGE: {app_name} REPORT_NAME URL_TO_EPRINTS \\
+        OUTPUT_CSV_FILE [SAMPLE_SIZE]
+
+EXAMPLE:
+
+    {app_name} creator \\
+        'https://username:secret@eprint.example.edu' \\
+        creator_report.csv
+
+    {app_name} doi \\
+        'https://username:secret@eprint.example.edu' \\
+        doi_report.csv
+''')
+    if msg != "":
+        print("")
+        print(msg)
+    sys.exit(exit_code)
+
+#
+# creator_report crawls the EPrints REST API and accumulates 
+# creators, orcids and their eprint article
+# numbers. Returns a list in a table format.
+#
+def creator_report(eprint_url, csv_filename, sample_size = 0):
+    print(f"Retrieving keys from {eprint_url}, saving report to {csv_filename}")
+    keys = get_eprint_keys(eprint_url)
+    if keys == None:
+        print(f"ERROR: could not get keys, check URL {eprint_url}")
+        sys.exit(1)
+    
+    if len(keys) == 0:
+        print(f"ERROR: no keys returned for {eprint_url}")
+        sys.exit(1)
+    
+    # NOTE: You can debug using a sample_size > 0
+    if sample_size > 0:
+        keys = random.sample(keys, sample_size)
+    keys.sort(key=int, reverse = True)
+    
+    creators = {}
+    creator_ids = []
+    i = 0
+    j = 0
+    print(f"Processing {len(keys)} eprint records for creators")
+    for eprint_id in keys:
+        obj = get_eprint(eprint_url, eprint_id)
+        if obj != None:
+            if 'creators' in obj and 'items' in obj['creators']:
+                items = obj['creators']['items']
+                for item in items:
+                    if 'id' in item:
+                        creator_id = item['id']
+                        orcid = '' 
+                        if 'orcid' in item:
+                            orcid = item['orcid']
+                        if creator_id in creators:
+                            creators[creator_id]['eprint_ids'].append(eprint_id)
+                            if orcid != '':
+                                if not orcid in creators[creator_id]['orcids']:
+                                    creators[creator_id]['orcids'].append(orcid)
+                        else:
+                            j += 1
+                            creators[creator_id] = {}
+                            if orcid != '':
+                                creators[creator_id]['orcids'] = [orcid]
+                            else:
+                                creators[creator_id]['orcids'] = []
+                            creators[creator_id]['eprint_ids'] = [eprint_id]
+                            creator_ids.append(creator_id)
+        i += 1
+        if (i % batch_size) == 0:
+            print(f"Processed {i} eprints, found {j} creators, last eprint id processed {eprint_id}")
+    
+    print(f"Processed {i} eprints, found {j} creators, total")
+    
+    creator_ids.sort()
+    print("")
+    print(f"Collected creators from {eprint_url}, saving in {csv_filename}")
+    if os.path.exists(csv_filename):
+        os.remove(csv_filename)
+    with open(csv_filename, 'w', encoding = 'utf-8') as f:
+        f.write("Creator ID, ORCID(s), EPrint ID(s)\n")
+        for creator_id in creator_ids:
+            creator = creators[creator_id]
+            orcid = "|".join(creator['orcids'])
+            eprint_ids = "|".join(creator['eprint_ids'])
+            print(f"Writing: {creator_id},{orcid},{eprint_ids}")
+            f.write(f"{creator_id},{orcid},{eprint_ids}\n")
+    print("All Done!")
+    
+
+
+#
+# doi_report crawls the EPrints REST API and accumulates doi and
+# returns a list one per line.
+#
+def doi_report(eprint_url, csv_filename, sample_size = 0):
+    print(f"Retrieving keys from {eprint_url}, saving report to {csv_filename}")
+    keys = get_eprint_keys(eprint_url)
+    if keys == None:
+        print(f"ERROR: could not get keys, check URL {eprint_url}")
+        sys.exit(1)
+    
+    if len(keys) == 0:
+        print(f"ERROR: no keys returned for {eprint_url}")
+        sys.exit(1)
+    
+    
+    # NOTE: You can debug using a sample_size > 0
+    if sample_size > 0:
+        keys = random.sample(keys, sample_size)
+    keys.sort(key=int, reverse = True)
+    
+    dois = []
+    i = 0
+    j = 0
+    print(f"Processing {len(keys)} eprint records for doi")
+    for eprint_id in keys:
+        obj = get_eprint(eprint_url, eprint_id)
+        if obj != None:
+            doi, itype, description = '', '', ''
+            if 'related_url' in obj and 'items' in obj['related_url']:
+                items = obj['related_url']['items']
+                for item in items:
+                    if 'url' in item:
+                        doi = item['url'].strip()
+                    if 'type' in item:
+                        itype = item['type'].strip().lower()
+                    if 'description' in item:
+                        description = item['description'].strip().lower()
+                    if itype == 'doi' and description == 'article':
+                        #print(f"{doi}")
+                        dois.append(doi)
+                        j += 1
+                        break
+            elif 'doi' in obj:
+                doi = obj['doi'].strip()
+                dois.append(doi)
+                j += 1
+        i += 1
+        if (i % batch_size) == 0:
+            print(f"Processed {i} eprints, {j} doi, last eprint id processed {eprint_id}")
+    
+    print(f"Processed {i} eprints, found {j} doi, total")
+    
+    print("")
+    print(f"Collected doi from {eprint_url}, saving in {csv_filename}")
+    if os.path.exists(csv_filename):
+        os.remove(csv_filename)
+    with open(csv_filename, 'w', encoding = 'utf-8') as f:
+        f.write("doi\n")
+        for doi in dois:
+            print(f"Writing: {doi}")
+            f.write(f"{doi}\n")
+    print("All Done!")
+
+#
+# Main script setup and processing
+#
+
+if len(sys.argv) < 4:
+    usage("", 1)
+report_name = sys.argv[1]
+eprint_url = sys.argv[2]
+csv_filename = sys.argv[3]
+sample_size = 0
+if len(sys.argv) > 4:
+    sample_size = int(sys.argv[4])
+
+if report_name == "creator":
+    creator_report(eprint_url, csv_filename, sample_size)
+elif report_name == "doi":
+    doi_report(eprint_url, csv_filename, sample_size)
+else:
+    usage(f"ERROR: unknown report name, {report_name}", 1)
+

--- a/run_eprint_report.py
+++ b/run_eprint_report.py
@@ -94,7 +94,7 @@ def creator_report(eprint_url, csv_filename, sample_size = 0):
     if os.path.exists(csv_filename):
         os.remove(csv_filename)
     with open(csv_filename, 'w', encoding = 'utf-8') as f:
-        f.write("Creator ID, ORCID(s), EPrint ID(s)\n")
+        f.write("creator_id,orcid,eprint_id\n")
         for creator_id in creator_ids:
             creator = creators[creator_id]
             orcid = "|".join(creator['orcids'])

--- a/run_eprint_report.py
+++ b/run_eprint_report.py
@@ -73,19 +73,22 @@ def creator_report(eprint_url, csv_filename, sample_size = 0):
                             if orcid != '':
                                 if not orcid in creators[creator_id]['orcids']:
                                     creators[creator_id]['orcids'].append(orcid)
+                            elif orcid == "" and len(creators[creator_id]['orcids']) > 0:
+                                creators[creator_id]['update_ids'].append(eprint_id)
                         else:
+                            # We have a new creator
                             j += 1
                             creators[creator_id] = {}
+                            creators[creator_id]['eprint_ids'] = [eprint_id]
+                            creators[creator_id]['update_ids'] = []
                             if orcid != '':
                                 creators[creator_id]['orcids'] = [orcid]
                             else:
                                 creators[creator_id]['orcids'] = []
-                            creators[creator_id]['eprint_ids'] = [eprint_id]
                             creator_ids.append(creator_id)
         i += 1
         if (i % batch_size) == 0:
             print(f"Processed {i} eprints, found {j} creators, last eprint id processed {eprint_id}")
-    
     print(f"Processed {i} eprints, found {j} creators, total")
     
     creator_ids.sort()
@@ -94,13 +97,14 @@ def creator_report(eprint_url, csv_filename, sample_size = 0):
     if os.path.exists(csv_filename):
         os.remove(csv_filename)
     with open(csv_filename, 'w', encoding = 'utf-8') as f:
-        f.write("creator_id,orcid,eprint_id\n")
+        f.write("creator_id,orcid,eprint_id,update_ids\n")
         for creator_id in creator_ids:
             creator = creators[creator_id]
             orcid = "|".join(creator['orcids'])
             eprint_ids = "|".join(creator['eprint_ids'])
-            print(f"Writing: {creator_id},{orcid},{eprint_ids}")
-            f.write(f"{creator_id},{orcid},{eprint_ids}\n")
+            update_ids = "|".join(creator['update_ids'])
+            print(f"Writing: {creator_id},{orcid},{eprint_ids},{update_ids}")
+            f.write(f"{creator_id},{orcid},{eprint_ids},{update_ids}\n")
     print("All Done!")
     
 


### PR DESCRIPTION
I've added support methods for wrapping eputil and epfmt. Also added run_eprint_report.py and run_eprint_attach_orcid.py.  Both are functional though I am still figuring out how to get EPrints to treat the validated EPrint XML as an update versus a new record so run_eprint_attach_orcid.py may change or be removed if have to take a different approach to getting my ORCIDs to attach in EPrints.